### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Heptagram is the all-in-one, open-source Discord bot with the goal to be the sin
 <br/>
 No more music bot, mod bot, rules bot. Just Heptagram
 
-Check out the website [here](https://heptagram.xyz)
+Check out the website [here](https://heptagram.jaspermayone.com/)
 
 ## 🤝 Contributing
 
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/Heptagram-Bot/heptagram.xyz/issues). If you are interested in contributing, we ask that you take a look at the [contributing guide](https://github.com/Heptagram-Bot/Heptagram/blob/master/CONTRIBUTING.md) before you contribute.
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/Heptagram-Bot-Project/website/issues). If you are interested in contributing, we ask that you take a look at the [contributing guide](https://github.com/Heptagram-Bot-Project/bot/blob/master/CONTRIBUTING.md) before you contribute.
 
 ## 😎 Heptagram Team
 
@@ -33,4 +33,4 @@ Give a ⭐️ if this project helped you!
 
 ## ✏ Discord Server
 
-Heptagram has a community Discord server. You can join it at [https://discord.gg/HSupF99kpq](https://discord.gg/HSupF99kpq). In the server you can suggest features, talk with developers, and test out the bot for yourself. If you have made an Open Source Contribution, you can gain access to a special role and channels. To do so, join the server and then ping any admin and let them know.
+Heptagram has a community Discord server. You can join it at [https://discord.gg/pKmY7jsp4E](https://discord.gg/pKmY7jsp4E). In the server you can suggest features, talk with developers, and test out the bot for yourself. If you have made an Open Source Contribution, you can gain access to a special role and channels. To do so, join the server and then ping any admin and let them know.


### PR DESCRIPTION
Some links were changed, so i fixed that.

Example : 
- The website link : from heptagram.xyz to heptagram.jaspermayone.com
- The repo link
- The Discord Server link